### PR TITLE
fix: Add Vite entry point script to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,19 +41,9 @@
         scrollbar-width: none;
       }
     </style>
-  <script type="importmap">
-{
-  "imports": {
-    "@google/genai": "https://aistudiocdn.com/@google/genai@^1.32.0",
-    "react/": "https://aistudiocdn.com/react@^19.2.1/",
-    "react": "https://aistudiocdn.com/react@^19.2.1",
-    "lucide-react": "https://aistudiocdn.com/lucide-react@^0.557.0",
-    "react-dom/": "https://aistudiocdn.com/react-dom@^19.2.1/"
-  }
-}
-</script>
 </head>
   <body>
     <div id="root"></div>
+    <script type="module" src="/index.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Remove AI Studio importmap (not needed with Vite bundling) and add the module script tag pointing to index.tsx so the app actually loads.

https://claude.ai/code/session_01HArvbB1eJgPmdqt8bMikxG