### PR TITLE
feat: Admin task edit/delete, member history, expandable tasks

### DIFF
--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Task, TaskStatus } from '../types';
 import { useGame } from '../context/GameContext';
 import { Button } from './Button';
-import { Clock, Trophy, User as UserIcon, AlertCircle, Sparkles, Users, Lock } from 'lucide-react';
+import { Clock, Trophy, User as UserIcon, AlertCircle, Sparkles, Users, Lock, ChevronDown, ChevronUp } from 'lucide-react';
 
 interface TaskCardProps {
   task: Task;
@@ -15,6 +15,7 @@ interface TaskCardProps {
 
 export const TaskCard: React.FC<TaskCardProps> = ({ task, onClaim, onComplete, variant = 'market', isLocked = false, lockReason }) => {
   const { currentUser, getPotentialPoints, users } = useGame();
+  const [expanded, setExpanded] = useState(false);
   
   // Calculate points for the viewer
   const points = currentUser ? getPotentialPoints(task, currentUser.id) : task.basePoints;
@@ -55,11 +56,25 @@ export const TaskCard: React.FC<TaskCardProps> = ({ task, onClaim, onComplete, v
 
       <div className="flex justify-between items-start mb-2">
         <div className="flex-1 pr-2">
-          <h3 className="font-display font-bold text-gray-800 text-lg leading-tight flex items-center gap-2">
-             {isLocked && <Lock size={16} className="text-gray-400" />}
-             {task.title}
-          </h3>
-          <p className="text-sm text-gray-500 mt-1 line-clamp-2">{task.description}</p>
+          {variant === 'my-tasks' ? (
+            <button className="text-left w-full" onClick={() => setExpanded(!expanded)}>
+              <h3 className="font-display font-bold text-gray-800 text-lg leading-tight flex items-center gap-2">
+                {task.title}
+                {task.description && (
+                  expanded ? <ChevronUp size={16} className="text-gray-400 shrink-0" /> : <ChevronDown size={16} className="text-gray-400 shrink-0" />
+                )}
+              </h3>
+              <p className={`text-sm text-gray-500 mt-1 ${expanded ? '' : 'line-clamp-1'}`}>{task.description}</p>
+            </button>
+          ) : (
+            <>
+              <h3 className="font-display font-bold text-gray-800 text-lg leading-tight flex items-center gap-2">
+                {isLocked && <Lock size={16} className="text-gray-400" />}
+                {task.title}
+              </h3>
+              <p className="text-sm text-gray-500 mt-1 line-clamp-2">{task.description}</p>
+            </>
+          )}
         </div>
         <div className="flex flex-col items-end shrink-0">
           <div className={`

--- a/context/GameContext.tsx
+++ b/context/GameContext.tsx
@@ -25,6 +25,8 @@ interface GameContextType {
 
   // Tasks
   addTask: (task: Omit<Task, 'id' | 'createdAt' | 'status' | 'createdBy' | 'familyId'>) => Promise<void>;
+  editTask: (taskId: string, data: { title?: string; description?: string; basePoints?: number; userPointsOverride?: Record<string, number>; bookingDeadline?: number; completionDeadline?: number }) => Promise<void>;
+  deleteTask: (taskId: string) => Promise<void>;
   claimTask: (taskId: string) => Promise<void>;
   completeTask: (taskId: string) => Promise<void>;
   verifyTask: (taskId: string) => Promise<void>;
@@ -233,6 +235,16 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     await refreshData();
   };
 
+  const editTask = async (taskId: string, data: { title?: string; description?: string; basePoints?: number; userPointsOverride?: Record<string, number>; bookingDeadline?: number; completionDeadline?: number }) => {
+    await api.tasks.update(taskId, data);
+    await refreshData();
+  };
+
+  const deleteTask = async (taskId: string) => {
+    await api.tasks.delete(taskId);
+    await refreshData();
+  };
+
   const claimTask = async (taskId: string) => {
     await api.tasks.claim(taskId);
     await refreshData();
@@ -329,6 +341,8 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
       logout,
       updateUserRole,
       addTask,
+      editTask,
+      deleteTask,
       claimTask,
       completeTask,
       verifyTask,

--- a/services/api.ts
+++ b/services/api.ts
@@ -92,6 +92,20 @@ export const api = {
       request<{ success: boolean }>(`/api/tasks/${id}/complete`, { method: 'PUT' }),
     verify: (id: string) =>
       request<{ success: boolean }>(`/api/tasks/${id}/verify`, { method: 'PUT' }),
+    update: (id: string, data: {
+      title?: string;
+      description?: string;
+      basePoints?: number;
+      userPointsOverride?: Record<string, number>;
+      bookingDeadline?: number;
+      completionDeadline?: number;
+    }) =>
+      request<ApiTask>(`/api/tasks/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }),
+    delete: (id: string) =>
+      request<{ success: boolean }>(`/api/tasks/${id}`, { method: 'DELETE' }),
   },
 
   proposals: {


### PR DESCRIPTION
- Admin can now edit (title, description, points) and delete published tasks from the Admin view
- Clicking a member in Admin shows their completed tasks from the last 7 days in a modal
- Task cards in "Dina uppdrag" are now clickable to expand and read the full description
- Added PUT /api/tasks/:id and DELETE /api/tasks/:id endpoints
- Added editTask/deleteTask to GameContext and API client

https://claude.ai/code/session_01HArvbB1eJgPmdqt8bMikxG